### PR TITLE
Update the dockerfile to support cdk8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.9-alpine
+FROM python:3.9-slim-buster
 
 WORKDIR /app
 
-RUN apk --no-cache add yarn npm
-RUN yarn global add cdk8s-cli && yarn cache clean
+RUN apt-get update && apt-get install -y curl
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
+# RUN npm i -g cdk8s-cli
 RUN pip install pipenv
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
-FROM python:3.9-slim AS builder
-ADD . /app
+FROM python:3.9-alpine
+
 WORKDIR /app
 
-# Install pipenv
+RUN apk --no-cache add yarn npm
+RUN yarn global add cdk8s-cli && yarn cache clean
 RUN pip install pipenv
 
 # Install dependencies
-COPY Pipfile* ./
+COPY . .
 RUN pipenv lock --requirements > requirements.txt
 RUN pip install --target=/app -r requirements.txt
 
-# A distroless container image with Python and some basics like SSL certificates
-# https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3-debian10
-
-COPY --from=builder /app /app
-WORKDIR /app
-ENV PYTHONPATH /app
-
-ENTRYPOINT ["/app/main.py"]
+CMD ["/app/main.py"]
+ENTRYPOINT ["python"]


### PR DESCRIPTION
By using the old dockerfile we didn't get nodejs and cdk8s-cli to run as a subprocess of python, so it had to be installed. This means we had to update the entire dockerfile to make it work.