### PR TITLE
Prepend INPUT_ to the envs coming from github action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ COPY . .
 RUN pipenv lock --requirements > requirements.txt
 RUN pip install --target=/app -r requirements.txt
 
-CMD ["/app/main.py"]
-ENTRYPOINT ["python"]
+ENTRYPOINT ["/app/main.py"]

--- a/utils/inputs.py
+++ b/utils/inputs.py
@@ -27,13 +27,13 @@ class Inputs:
     @classmethod
     def from_env(cls):
         return Inputs(
-            app_name=os.getenv("app_name", ""),
-            namespace=os.getenv("namespace", ""),
-            docker_image=os.getenv("docker_image"),
-            replicas=int(os.getenv("replicas", "1")),
-            port=int(os.getenv("port", "3000")),
-            container_port=int(os.getenv("container_port")),
-            ingress=bool(strtobool(os.getenv("ingress", "false"))),
-            ingress_host=os.getenv("ingress_host"),
-            ingress_path=os.getenv("ingress_path", "/"),
+            app_name=os.getenv("INPUT_APP_NAME", ""),
+            namespace=os.getenv("INPUT_NAMESPACE", ""),
+            docker_image=os.getenv("INPUT_DOCKER_IMAGE"),
+            replicas=int(os.getenv("INPUT_REPLICAS", "1")),
+            port=int(os.getenv("INPUT_PORT", "3000")),
+            container_port=int(os.getenv("INPUT_CONTAINER_PORT")),
+            ingress=bool(strtobool(os.getenv("INPUT_INGRESS", "false"))),
+            ingress_host=os.getenv("INPUT_INGRESS_HOST"),
+            ingress_path=os.getenv("INPUT_INGRESS_PATH", "/"),
         )


### PR DESCRIPTION
Example from the runner:
```bash
/usr/bin/docker run --name a73fc824bc11ba42fe898605595ac8f50f_98e5ee --label 9916a7 --workdir /github/workspace --rm -e INPUT_APP_NAME -e INPUT_NAMESPACE -e INPUT_DOCKER_IMAGE -e INPUT_REPLICAS -e INPUT_PORT -e INPUT_CONTAINER_PORT -e INPUT_INGRESS -e INPUT_INGRESS_HOST -e INPUT_INGRESS_PATH -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/deploy-service/deploy-service":"/github/workspace" 9916a7:3fc824bc11ba42fe898605595ac8f50f  "prevent-ui" "development" "833870238474.dkr.ecr.eu-north-1.amazonaws.com/prevent-ui:9628f958eb4a69571cfee558624fa0a33fa49c4f" "1" "80" "80" "true" "/" "prevent.dev.dignio.dev"
```

However, by doing it like this it does not inject any values to the ENV vars at all, but is calling the image with values that is used as arguments. Simplified example:
```bash
docker run image_name "argument 1" "argument 2" "argument 3"
```

and since this is the case, we have to use sys.argv in order to fetch them. However, then they have to be in the correct order all the time, which is not a great approach at ALL.

Example templates
Using sys.argv: https://github.com/cicirello/python-github-action-template/blob/main/entrypoint.py
Using getenv: 
* https://github.com/jacobtomlinson/python-container-action/blob/master/main.py
* https://github.com/k2bd/action-python-poetry/blob/main/src/action_python_poetry/constants.py

I guess we would just have to test