### PR TITLE
PLAT-490: Pass instance to manifest generation

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 INPUT_APP_NAME="prevent-ui"
 INPUT_SERVICE_TYPE="webservice"
+INPUT_INSTANCE="development"
 INPUT_NAMESPACE="development"
 INPUT_DOCKER_IMAGE="1337.dkr.ecr.eu-north-1.amazonaws.com/prevent-ui:9628f958eb4a69571cfee558624fa0a33fa49c4f"
 INPUT_REPLICAS="1"

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           # These must be specified for the action to work
           app_name: prevent-ui
-          service_type: webservice.
+          service_type: webservice
           instance: development
           namespace: development
           docker_image: 1337.dkr.ecr.eu-north-1.amazonaws.com/prevent-ui:9628f958eb4a69571cfee558624fa0a33fa49c4f

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -9,13 +9,14 @@ jobs:
       - uses: actions/checkout@v2
 
       # === Test against the repo's copy of the action
-      - uses: ./  
+      - uses: ./
         name: Generate the Kubernetes manifest
         id: generate_manifest
         with:
           # These must be specified for the action to work
           app_name: prevent-ui
           service_type: webservice.
+          instance: development
           namespace: development
           docker_image: 1337.dkr.ecr.eu-north-1.amazonaws.com/prevent-ui:9628f958eb4a69571cfee558624fa0a33fa49c4f
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ pipenv install
 pipenv run generate
 ```
 
----
+## Tests
+This action is using the `fixture/prevent-ui.yaml` while running the `.github/workflows/test-action.yaml` to validate the output is correct

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It aims to a generic generator that can generate any manifest we'll need for dep
     # These must be specified for the action to work
     app_name: prevent-ui
     service_type: webservice
+    instance: development
     namespace: development
     docker_image: <org-id>.dkr.ecr.<region>.amazonaws.com/<repo-name>:<tag>
 

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,9 @@ inputs:
     description: 'Service type selector. I.e. webservice.'
     required: true
     default: ''
+  instance:
+    description: 'The instance we want to build the manifest for. I.e. development.'
+    required: true
   namespace:
     description: 'The Kubernetes namespace'
     required: true
@@ -46,6 +49,8 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.app_name }}
+    - ${{ inputs.service_type }}
+    - ${{ inputs.instance }}
     - ${{ inputs.namespace }}
     - ${{ inputs.docker_image }}
     - ${{ inputs.replicas }}

--- a/fixture/prevent-ui.yaml
+++ b/fixture/prevent-ui.yaml
@@ -66,14 +66,14 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "20"
     alb.ingress.kubernetes.io/healthcheck-path: /
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/load-balancer-name: ingress-prevent-ui
+    alb.ingress.kubernetes.io/load-balancer-name: ingress-development-prevent-ui
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-1-2017-01
     alb.ingress.kubernetes.io/success-codes: "200"
     kubernetes.io/ingress.class: alb
   labels:
     app: prevent-ui
-  name: prevent-ui
+  name: development-prevent-ui
   namespace: development
 spec:
   rules:

--- a/manifests/ingress.py
+++ b/manifests/ingress.py
@@ -1,5 +1,5 @@
 from cdk8s import ApiObjectMetadata
-from constructs import Construct
+from cdk8s import App
 from cdk8s_plus_22 import Ingress
 from cdk8s_plus_22 import IngressRule
 from cdk8s_plus_22 import IngressBackend
@@ -8,11 +8,11 @@ from cdk8s_plus_22 import HttpIngressPathType
 from utils.inputs import Inputs
 
 
-def create_ingress(manifest: Construct, inputs: Inputs, data: dict) -> None:
+def create_ingress(manifest: App, inputs: Inputs, data: dict) -> None:
     """This function will add an ingress to the webservice object
 
     Args:
-        manifest (Construct): The manifest object we attach the ingress to
+        manifest (App): The manifest object we attach the ingress to
         inputs (Inputs): The Github action INPUT arguments
         data (dict): Data defined by the service which are using this method. I.e. labels
     """

--- a/manifests/ingress.py
+++ b/manifests/ingress.py
@@ -1,0 +1,45 @@
+from cdk8s import ApiObjectMetadata
+from constructs import Construct
+from cdk8s_plus_22 import Ingress
+from cdk8s_plus_22 import IngressRule
+from cdk8s_plus_22 import IngressBackend
+from cdk8s_plus_22 import HttpIngressPathType
+
+from utils.inputs import Inputs
+
+
+def create_ingress(manifest: Construct, inputs: Inputs, data: dict) -> None:
+    """This function will add an ingress to the webservice object
+
+    Args:
+        manifest (Construct): The manifest object we attach the ingress to
+        inputs (Inputs): The Github action INPUT arguments
+        data (dict): Data defined by the service which are using this method. I.e. labels
+    """
+    Ingress(
+        manifest,
+        id=inputs.app_name,
+        metadata=ApiObjectMetadata(
+            name=f"{inputs.instance}-{inputs.app_name}",
+            labels=data["labels"],
+            namespace=inputs.namespace,
+            annotations={
+                "kubernetes.io/ingress.class": "alb",
+                "alb.ingress.kubernetes.io/scheme": "internet-facing",
+                "alb.ingress.kubernetes.io/listen-ports": '[{"HTTPS":443}]',
+                "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-1-2017-01",
+                "alb.ingress.kubernetes.io/healthcheck-path": "/",
+                "alb.ingress.kubernetes.io/healthcheck-interval-seconds": "20",
+                "alb.ingress.kubernetes.io/success-codes": "200",
+                "alb.ingress.kubernetes.io/load-balancer-name": f"ingress-{inputs.instance}-{inputs.app_name}",
+            },
+        ),
+        rules=[
+            IngressRule(
+                backend=IngressBackend.from_service(service=data["service"], port=inputs.port),
+                host=inputs.ingress_host,
+                path=inputs.ingress_path,
+                path_type=HttpIngressPathType.PREFIX,
+            )
+        ],
+    )

--- a/manifests/webservice.py
+++ b/manifests/webservice.py
@@ -2,17 +2,14 @@ from cdk8s import ApiObjectMetadata
 from cdk8s import Duration
 from cdk8s_plus_22 import Service
 from cdk8s_plus_22 import Deployment
-from cdk8s_plus_22 import Ingress
-from cdk8s_plus_22 import IngressRule
-from cdk8s_plus_22 import IngressBackend
 from cdk8s_plus_22 import ServiceType
 from cdk8s_plus_22 import ContainerProps
 from cdk8s_plus_22 import RestartPolicy
 from cdk8s_plus_22 import Protocol
 from cdk8s_plus_22 import Probe
-from cdk8s_plus_22 import HttpIngressPathType
 from constructs import Construct
 
+from .ingress import create_ingress
 from utils.inputs import Inputs
 
 
@@ -89,30 +86,4 @@ class WebService(Construct):
 
         # Add an ingress, if necessary.
         if inputs.ingress:
-            Ingress(
-                webservice,
-                id=inputs.app_name,
-                metadata=ApiObjectMetadata(
-                    name=inputs.app_name,
-                    labels=labels,
-                    namespace=inputs.namespace,
-                    annotations={
-                        "kubernetes.io/ingress.class": "alb",
-                        "alb.ingress.kubernetes.io/scheme": "internet-facing",
-                        "alb.ingress.kubernetes.io/listen-ports": '[{"HTTPS":443}]',
-                        "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-1-2017-01",
-                        "alb.ingress.kubernetes.io/healthcheck-path": "/",
-                        "alb.ingress.kubernetes.io/healthcheck-interval-seconds": "20",
-                        "alb.ingress.kubernetes.io/success-codes": "200",
-                        "alb.ingress.kubernetes.io/load-balancer-name": f"ingress-{inputs.app_name}",
-                    },
-                ),
-                rules=[
-                    IngressRule(
-                        backend=IngressBackend.from_service(service=service, port=inputs.port),
-                        host=inputs.ingress_host,
-                        path=inputs.ingress_path,
-                        path_type=HttpIngressPathType.PREFIX,
-                    )
-                ],
-            )
+            create_ingress(webservice, inputs, {"service": service, "labels": labels})

--- a/utils/inputs.py
+++ b/utils/inputs.py
@@ -10,6 +10,7 @@ class Inputs:
     # Mandatory attributes
     app_name: str
     service_type: str
+    instance: str
     namespace: str
     docker_image: str
 
@@ -30,6 +31,7 @@ class Inputs:
         return Inputs(
             app_name=os.getenv("INPUT_APP_NAME", ""),
             service_type=os.getenv("INPUT_SERVICE_TYPE", ""),
+            instance=os.getenv("INPUT_INSTANCE", ""),
             namespace=os.getenv("INPUT_NAMESPACE", ""),
             docker_image=os.getenv("INPUT_DOCKER_IMAGE"),
             replicas=int(os.getenv("INPUT_REPLICAS", "1")),


### PR DESCRIPTION
* Add the instance as an input to use it for naming i.e. the ingress so it does not conflict with other ingresses in the same region
* Move the ingress generation to its own function
* Update the test

Example error from an ingress if another with identical name exist within the same namespace:
```bash
 Warning  FailedDeployModel  2s                     ingress  Failed deploy model due to DuplicateLoadBalancerName: A load balancer with the same name '<ingress-name>' exists, but with different settings
 ```

Ticket: https://dignio.atlassian.net/browse/PLAT-490?atlOrigin=eyJpIjoiYWIxYzY0N2Q5NWY5NDZlOGFjMzBkMzA3MTU3MTllNGUiLCJwIjoiaiJ9